### PR TITLE
Add hide and toggle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Requirements: in `party` or `raid`, attacking `elite` creatures or `bosses`.
 
 ## Slashcommands
 - `/twtshow`
-- `/twt show` 
+- `/twt show`
+- `/twt hide`
+- `/twt toggle`
 - `/twt tankmode`
 
 ## Settings

--- a/TWThreat.lua
+++ b/TWThreat.lua
@@ -146,6 +146,21 @@ SlashCmdList["TWT"] = function(cmd)
             TWT_CONFIG.visible = true
             return true
         end
+        if __substr(cmd, 1, 4) == 'hide' then
+            _G['TWTMain']:Hide()
+            TWT_CONFIG.visible = false
+            return true
+        end
+        if __substr(cmd, 1, 6) == 'toggle' then
+            if TWT_CONFIG.visible then
+                _G['TWTMain']:Hide()
+                TWT_CONFIG.visible = false
+            else
+                _G['TWTMain']:Show()
+                TWT_CONFIG.visible = true
+            end
+            return true
+        end
         if __substr(cmd, 1, 8) == 'tankmode' then
             if TWT_CONFIG.tankMode then
                 twtprint('Tank Mode is already enabled.')
@@ -186,6 +201,8 @@ SlashCmdList["TWT"] = function(cmd)
 
         twtprint(TWT.addonName .. ' |cffabd473v' .. TWT.addonVer .. '|cffffffff available commands:')
         twtprint('/twt show - shows the main window (also /twtshow)')
+        twtprint('/twt hide - hides the main window')
+        twtprint('/twt toggle - show/hide the main window')
     end
 end
 


### PR DESCRIPTION
### Description
This commit adds new commands:

1. /twt hide - to hide the main window
2. /twt toggle - toggles the main windows between hidden and showed states

The in game message and README was updated to show new commands.

### Use case
The idea was inspired by shagudps meter. I like to have a macros that toggles ON/OFF my dps and threat meters(toggle commands).
Some people may like to have two different macroses, one to toggle ON and other to toggle OFF(hide command).
I just think that it would be nice to have an option to automate this using the macro.